### PR TITLE
20250327 Aaron's Suggestion

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -1,28 +1,34 @@
-Cypress.Commands.overwrite('fixture', (originalFn, filePath, encoding, options) => {
-    if (filePath.endsWith('.js')) {
-        // The plugin stored all our fixture data here
-        const allJsFixtures = Cypress.env('__ALL_JS_FIXTURES__') || {};
+function fixtureOverwriteCommand(Cypress) {
+    Cypress.Commands.overwrite('fixture', (originalFn, filePath, encoding, options) => {
+        if (filePath.endsWith('.js')) {
+            // The plugin stored all our fixture data here
+            const allJsFixtures = Cypress.env('__ALL_JS_FIXTURES__') || {};
 
-        // Optional: some debug logging
-        const isDebug = process.env.NODE_ENV !== 'production';
-        if (isDebug) {
-            console.log('[dynamic-fixtures] filePath =>', filePath);
-            console.log('[dynamic-fixtures] allJsFixtures keys =>', Object.keys(allJsFixtures));
+            // Optional: some debug logging
+            const isDebug = process.env.NODE_ENV !== 'production';
+            if (isDebug) {
+                console.log('[dynamic-fixtures] filePath =>', filePath);
+                console.log('[dynamic-fixtures] allJsFixtures keys =>', Object.keys(allJsFixtures));
+            }
+
+            // Transform file path the same way we did in plugin.js
+            let noExt = filePath.replace(/\.js$/, '');
+            let replaced = noExt.replace(/\//g, '$');
+            let transformedKey = replaced.replace(/-([a-zA-Z])/g, (_, c) => c.toUpperCase());
+
+            if (isDebug) {
+                console.log('[dynamic-fixtures] transformedKey =>', transformedKey);
+            }
+
+            // Return the matching object from the dictionary
+            return Cypress.Promise.resolve(allJsFixtures[transformedKey]);
         }
 
-        // Transform file path the same way we did in plugin.js
-        let noExt = filePath.replace(/\.js$/, '');
-        let replaced = noExt.replace(/\//g, '$');
-        let transformedKey = replaced.replace(/-([a-zA-Z])/g, (_, c) => c.toUpperCase());
+        // For non .js fixtures, call the original fixture function
+        return originalFn(filePath, encoding, options);
+    });
 
-        if (isDebug) {
-            console.log('[dynamic-fixtures] transformedKey =>', transformedKey);
-        }
+    return Cypress;
+}
 
-        // Return the matching object from the dictionary
-        return Cypress.Promise.resolve(allJsFixtures[transformedKey]);
-    }
-
-    // For non .js fixtures, call the original fixture function
-    return originalFn(filePath, encoding, options);
-});
+module.exports = { fixtureOverwriteCommand };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const { dynamicFixturePlugin } = require('./plugin'); // Re-export the plugin so user can import it easily
-require('./commands'); // commands.js overwrites `cy.fixture`
+// require('./commands'); // commands.js overwrites `cy.fixture`
 
 module.exports = {
     dynamicFixturePlugin

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const glob = require("glob");
+const {fixtureOverwriteCommand} = require('src/commands');
 
 /**
  * Gathers all .js fixtures from cypress/fixtures (by default) and transforms them
@@ -11,6 +12,8 @@ const glob = require("glob");
  * @returns {Object} updated config
  */
 function dynamicFixturePlugin(on, config, options = {}) {
+    fixtureOverwriteCommand(Cypress);
+
     // By default, assume cypress/fixtures as the fixtures directory
     const fixturesDir = options.fixturesDir
         ? path.resolve(options.fixturesDir)


### PR DESCRIPTION
Approach to call fixtureOverwriteCommand(Cypress) won’t work because the Cypress object isn’t available in that context. The Cypress global is only available in the browser’s context (i.e. in support files or test code), not in the Node environment where the plugin code runs. When the plugin (in setupNodeEvents) calls `fixtureOverwriteCommand(Cypress)`, Cypress is not defined.

Basically,
1. Node Plugin: Runs in setupNodeEvents to gather fixture files and store them in config.env.__ALL_JS_FIXTURES__.

2. Support File: Imports your commands file, which then overwrites cy.fixture() using the Cypress object available in the browser.
   - NOTE: The user must import our command to their support file to "hook it up" - see here in our documentation: https://github.com/GregJacobs82/cypress-dynamic-fixtures?tab=readme-ov-file#2-import